### PR TITLE
Lower-case TLD lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
 	for _, url := range urls {
 		u, _ := tld.Parse(url)
 		fmt.Printf("%50s = [ %s ] [ %s ] [ %s ] [ %s ] [ %s ] [ %t ]\n",
-			u, u.Subdomain, u.Domain, u.TLD, u.Port, u.Path, u.Icann)
+			u, u.Subdomain, u.Domain, u.TLD, u.Port, u.Path, u.ICANN)
 	}
 }
 ```

--- a/example/main.go
+++ b/example/main.go
@@ -18,6 +18,6 @@ func main() {
 	for _, url := range urls {
 		u, _ := tld.Parse(url)
 		fmt.Printf("%50s = [ %s ] [ %s ] [ %s ] [ %s ] [ %s ] [ %t ]\n",
-			u, u.Subdomain, u.Domain, u.TLD, u.Port, u.Path, u.Icann)
+			u, u.Subdomain, u.Domain, u.TLD, u.Port, u.Path, u.ICANN)
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -31,7 +31,7 @@ func Parse(s string) (*URL, error) {
 	dom, port := domainPort(url.Host)
 	//etld+1
 	etld1, err := publicsuffix.EffectiveTLDPlusOne(dom)
-	_, icann := publicsuffix.PublicSuffix(dom)
+	_, icann := publicsuffix.PublicSuffix(strings.ToLower(dom))
 	if err != nil {
 		return nil, err
 	}

--- a/parse.go
+++ b/parse.go
@@ -14,7 +14,7 @@ import (
 //URL embeds net/url and adds extra fields ontop
 type URL struct {
 	Subdomain, Domain, TLD, Port string
-	Icann                        bool
+	ICANN                        bool
 	*url.URL
 }
 
@@ -49,7 +49,7 @@ func Parse(s string) (*URL, error) {
 		Domain:    domName,
 		TLD:       tld,
 		Port:      port,
-		Icann:     icann,
+		ICANN:     icann,
 		URL:       url,
 	}, nil
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -42,3 +42,7 @@ func Test4(t *testing.T) {
 func Test5(t *testing.T) {
 	run("https://foo.notmanaged", "", "foo", "notmanaged", false, t)
 }
+
+func Test6(t *testing.T) {
+	run("https://google.Com", "", "google", "Com", true, t)
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -14,8 +14,8 @@ func run(input, sub, dom, tld string, icann bool, t *testing.T) {
 		t.Errorf("should have Domain '%s', got '%s'", dom, u.Domain)
 	} else if u.Subdomain != sub {
 		t.Errorf("should have Subdomain '%s', got '%s'", sub, u.Subdomain)
-	} else if u.Icann != icann {
-		t.Errorf("should have Icann '%t', got '%t'", icann, u.Icann)
+	} else if u.ICANN != icann {
+		t.Errorf("should have Icann '%t', got '%t'", icann, u.ICANN)
 	}
 }
 


### PR DESCRIPTION
It looks like PublicSuffix is case sensitive when looking up TLDs, so `google.com` is ICANN-managed but `google.Com` is not, which is not correct (both are equivalent). This PR addresses this issue by lower-casing the domain before calling `PublicSuffix`
