### PR TITLE
Lower-case PublicSuffix lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
 	for _, url := range urls {
 		u, _ := tld.Parse(url)
 		fmt.Printf("%50s = [ %s ] [ %s ] [ %s ] [ %s ] [ %s ] [ %t ]\n",
-			u, u.Subdomain, u.Domain, u.TLD, u.Port, u.Path, u.Icann)
+			u, u.Subdomain, u.Domain, u.TLD, u.Port, u.Path, u.ICANN)
 	}
 }
 ```

--- a/parse.go
+++ b/parse.go
@@ -31,7 +31,7 @@ func Parse(s string) (*URL, error) {
 	dom, port := domainPort(url.Host)
 	//etld+1
 	etld1, err := publicsuffix.EffectiveTLDPlusOne(dom)
-	_, icann := publicsuffix.PublicSuffix(dom)
+	_, icann := publicsuffix.PublicSuffix(strings.ToLower(dom))
 	if err != nil {
 		return nil, err
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -42,3 +42,7 @@ func Test4(t *testing.T) {
 func Test5(t *testing.T) {
 	run("https://foo.notmanaged", "", "foo", "notmanaged", false, t)
 }
+
+func Test6(t *testing.T) {
+	run("https://google.Com", "", "google", "Com", true, t)
+}


### PR DESCRIPTION
It looks like PublicSuffix is case sensitive when looking up TLDs, so `google.com` is ICANN-managed but `google.Com` is not, which is not correct (both are equivalent). This PR addresses this issue by lower-casing the domain before calling `PublicSuffix`