### PR TITLE
Hack etld1 for non icann public suffixes

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -31,7 +31,12 @@ func Parse(s string) (*URL, error) {
 	dom, port := domainPort(url.Host)
 	//etld+1
 	etld1, err := publicsuffix.EffectiveTLDPlusOne(dom)
-	_, icann := publicsuffix.PublicSuffix(strings.ToLower(dom))
+	suffix, icann := publicsuffix.PublicSuffix(strings.ToLower(dom))
+	// HACK: attempt to support valid domains which are not registered with ICAN
+	if err != nil && !icann && suffix == dom {
+		etld1 = dom
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -46,3 +46,7 @@ func Test5(t *testing.T) {
 func Test6(t *testing.T) {
 	run("https://google.Com", "", "google", "Com", true, t)
 }
+
+func Test7(t *testing.T) {
+	run("https://github.io", "", "github", "io", false, t)
+}


### PR DESCRIPTION
Parsing fails to get `etld1` when the input URL matches a non icann address.
For example:
`https://github.io`
`https://myshopify.com` 
It fails with the following error:
`publicsuffix: cannot derive eTLD+1 for domain "github.com"`
This failure is expected, given those domains are registered as private suffixes.

The suggested hack handles this so that when it fails, it set `etld1` to `dom` for non icann and only if the returned suffix equals to the dom